### PR TITLE
Render Mode Fixes for gym 0.26+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 __pycache__/
 .ipynb_checkpoints/
-exp
-tb
-data
 
 # Experiment File/Folder
-model_weights
-outputs
-video
-eval.csv
-train.csv
+data/
+outputs/
+video/

--- a/logger.py
+++ b/logger.py
@@ -152,7 +152,7 @@ class Logger(object):
         self._log_dir = log_dir
         self._log_frequency = log_frequency
         if save_tb:
-            tb_dir = os.path.join(log_dir, "tb")
+            tb_dir = os.path.join(log_dir, "data/tb")
             if os.path.exists(tb_dir):
                 try:
                     shutil.rmtree(tb_dir)
@@ -165,8 +165,8 @@ class Logger(object):
         # each agent has specific output format for training
         assert agent in AGENT_TRAIN_FORMAT
         train_format = COMMON_TRAIN_FORMAT + AGENT_TRAIN_FORMAT[agent]
-        self._train_mg = MetersGroup(os.path.join(log_dir, "train"), formating=train_format)
-        self._eval_mg = MetersGroup(os.path.join(log_dir, "eval"), formating=COMMON_EVAL_FORMAT)
+        self._train_mg = MetersGroup(os.path.join(tb_dir, "train"), formating=train_format)
+        self._eval_mg = MetersGroup(os.path.join(tb_dir, "eval"), formating=COMMON_EVAL_FORMAT)
 
     def _should_log(self, step, log_frequency):
         log_frequency = log_frequency or self._log_frequency

--- a/train.py
+++ b/train.py
@@ -69,7 +69,7 @@ class Workspace(object):
             ep_goals_met = 0
             ep_hazard_touches = 0
 
-            while not done or truncated:
+            while not done and not truncated:
                 with utils.eval_mode(self.agent):
                     action = self.agent.act(obs, sample=False)
                 obs, reward, done, truncated, info = self.env.step(action)
@@ -96,8 +96,8 @@ class Workspace(object):
         self.logger.log("eval/hazard_touches", mean_hazard_touches, self.step)
         self.logger.log("eval/cost_limit_violations", cost_limit_violations, self.step)
         self.logger.dump(self.step)
-        self.agent.save(self.work_dir)
-        self.agent.save_actor(os.path.join(self.work_dir, "model_weights"), self.step)
+        self.agent.save(os.path.join(self.work_dir, "data"))
+        self.agent.save_actor(os.path.join(self.work_dir, "data/model_weights"), self.step)
 
     def run(self):
         episode, ep_reward, ep_cost, total_cost, done, truncated = 0, 0, 0, 0, True, True
@@ -155,7 +155,7 @@ class Workspace(object):
             obs = next_obs
             ep_step += 1
             self.step += 1
-        self.agent.save(self.work_dir)
+        self.agent.save(os.path.join(self.work_dir, "data"))
 
 
 @hydra.main(config_path='config', config_name='train', version_base=None)

--- a/train.py
+++ b/train.py
@@ -51,7 +51,7 @@ class Workspace(object):
         if cfg.restart_path != "dummy":
             self.agent.load(cfg.restart_path)
 
-        utils.make_dir(self.work_dir, "model_weights")
+        utils.make_dir(self.work_dir, "data/model_weights")
 
     def evaluate(self):
         mean_reward = 0

--- a/train_sac.py
+++ b/train_sac.py
@@ -62,7 +62,7 @@ class Workspace(object):
             self.video_recorder.init(enabled=(episode == 0))
             done, truncated = False, False
             episode_reward = 0
-            while not done or truncated:
+            while not done and not truncated:
                 with utils.eval_mode(self.agent):
                     action = self.agent.act(obs, sample=False)
                 obs, reward, done, truncated, _ = self.env.step(action)

--- a/utils.py
+++ b/utils.py
@@ -75,6 +75,7 @@ def make_custom_env(cfg):
         register(
             id="StaticEnv-v0",
             entry_point="safety_gym.envs.mujoco:Engine",
+            max_episode_steps=1000,
             kwargs={"config": config1},
         )
         env = gym.make("StaticEnv-v0", render_mode="rgb_array")
@@ -97,6 +98,7 @@ def make_custom_env(cfg):
         register(
             id="DynamicEnv-v0",
             entry_point="safety_gym.envs.mujoco:Engine",
+            max_episode_steps=1000,
             kwargs={"config": config2},
         )
         env = gym.make("DynamicEnv-v0", render_mode="rgb_array")

--- a/utils.py
+++ b/utils.py
@@ -40,7 +40,7 @@ def make_safety_env(cfg):
     env_split = cfg.env.split("_")
     env_name = f"Safexp-{env_split[0].capitalize()}{env_split[1].capitalize()}{env_split[-1]}-v0"
 
-    env = gym.make(env_name)
+    env = gym.make(env_name, render_mode="rgb_array")
     env.seed(cfg.seed)
 
     assert env.action_space.low.min() >= -1
@@ -99,7 +99,7 @@ def make_custom_env(cfg):
             entry_point="safety_gym.envs.mujoco:Engine",
             kwargs={"config": config2},
         )
-        env = gym.make("DynamicEnv-v0")
+        env = gym.make("DynamicEnv-v0", render_mode="rgb_array")
 
     return env
 

--- a/utils.py
+++ b/utils.py
@@ -77,7 +77,7 @@ def make_custom_env(cfg):
             entry_point="safety_gym.envs.mujoco:Engine",
             kwargs={"config": config1},
         )
-        env = gym.make("StaticEnv-v0")
+        env = gym.make("StaticEnv-v0", render_mode="rgb_array")
     else:
         config2 = {
             "placements_extents": [-1.5, -1.5, 1.5, 1.5],

--- a/video.py
+++ b/video.py
@@ -20,7 +20,6 @@ class VideoRecorder(object):
     def record(self, env):
         if self.enabled:
             frame = env.render(
-                mode="rgb_array",
                 height=self.height,
                 width=self.width,
                 camera_id=self.camera_id,

--- a/video.py
+++ b/video.py
@@ -5,7 +5,7 @@ import utils
 
 
 class VideoRecorder(object):
-    def __init__(self, root_dir, height=256, width=256, camera_id=0, fps=30):
+    def __init__(self, root_dir, height=1024, width=1024, camera_id=0, fps=30):
         self.save_dir = utils.make_dir(root_dir, "video") if root_dir else None
         self.height = height
         self.width = width


### PR DESCRIPTION
In new version of `gym`, `render_mode="rgb_array"` has to be specified in the environment constructor function `gym.make(name, render_mode)` instead of in the `env.render()` function.

Moved all files and folders created by running the experiment in a `data/` directory instead of having all the files in the root dir.

Fixed a little logic refuse in the `evaluate` function: 
`while not done or truncated` -> `while not done and not truncated`